### PR TITLE
Fix : allow Graphviz to display html label

### DIFF
--- a/nimgraphviz.nimble
+++ b/nimgraphviz.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "0.3.0"
+version       = "0.3.1"
 author        = "Quinn Freedman, then Alexis Masson"
 description   = "Nim bindings for the GraphViz tool and the DOT graph language"
 license       = "MIT"

--- a/src/nimgraphviz/graphs/graphs.nim
+++ b/src/nimgraphviz/graphs/graphs.nim
@@ -149,7 +149,11 @@ func exportSubDot(self: Graph): string # forward declaration
 
 func tableToAttributes(tbl: Table[string, string]): seq[string] =
   for (key, value) in tbl.pairs() :
-    result.add exportIdentifier(key) & "=" & exportIdentifier(value)
+    if key == "label" :
+      let is_likely_html = value.startsWith('<') and value.endsWith('>')
+      result.add exportIdentifier(key) & "=" & (if is_likely_html: value else: exportIdentifier(value))
+    else:
+      result.add exportIdentifier(key) & "=" & exportIdentifier(value)
 
 func exportAttributes(self: Graph): string =
   result = tableToAttributes(self.graphAttr).join(";\n")


### PR DESCRIPTION
Graphviz interpret and display a label value as HTML if it is HTML. See here
https://graphviz.org/docs/attrs/label/

Quoting :
If the value of a label attribute (label for nodes, edges, clusters, and graphs, and the headlabel and taillabel attributes of an edge) is given as an HTML string, that is, delimited by <...> rather than "...", the label is interpreted as an HTML description

-> perform 'a quick guess' (first and last character label values are '<' and '>' respectively).
If true, do not surround the label value with double quote.

Note : we could use a proper HTML parser but IMHO this is simplier and does not add dependency.